### PR TITLE
Fix code execution bug in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,4 +25,4 @@ sudo mv "bin/key" "/usr/bin/key"
 # Make it executable
 sudo chmod +x "/usr/bin/key"
 
-echo "Installation complete! Run `key newkey` if this is a first time installation."
+echo "Installation complete! Run \`key newkey\` if this is a first time installation."


### PR DESCRIPTION
Using backticks in a bash script will execute code. Lets fix this.